### PR TITLE
Redirect to login after signup

### DIFF
--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -32,7 +32,7 @@ const RegisterPage = () => {
         password: data.password,
       });
       if (result?.message) {
-        router.push("/");
+        router.push("/login");
         toast.success(result?.message || "Successfully LoggedIn!");
       }
       setIsLoading(false);


### PR DESCRIPTION
Work Done:

- Change route path to /login after the successful signup. 

Here is the linked issue: #5